### PR TITLE
allows the textfield of the tableview to become the dedicated first responder

### DIFF
--- a/UncrustifyX/Views/UXConfigOptionTableView.m
+++ b/UncrustifyX/Views/UXConfigOptionTableView.m
@@ -26,4 +26,11 @@
     return (row != -1 && ![self.delegate tableView:self isGroupRow:row]) ? [super menuForEvent:theEvent] : nil;
 }
 
+- (BOOL)validateProposedFirstResponder:(NSResponder *)responder forEvent:(NSEvent *)event {
+    if ([responder isKindOfClass:[NSTextField class]]) {
+        return YES;
+    }
+    return [super validateProposedFirstResponder:responder forEvent:event];
+}
+
 @end


### PR DESCRIPTION
Editing the textfields in the table view is not easy because when you click on them, the tableview grabs the first responder. This change allows the textfield to become the first responder when you click on it.
