### PR TITLE
Some improvements for the NSOpenPanel/NSSavePanel

### DIFF
--- a/UncrustifyX/UXDefaultsManager.h
+++ b/UncrustifyX/UXDefaultsManager.h
@@ -22,6 +22,7 @@
 @property (nonatomic) NSString *selectedPreviewLanguageInDocumentation;
 @property (nonatomic) NSString *selectedPreviewLanguageInMainWindow;
 @property (nonatomic) BOOL overwriteFiles;
+@property (nonatomic, assign) NSURL *lastConfigURL;
 
 /**
  * @return an array of NSStrings of the language code

--- a/UncrustifyX/UXDefaultsManager.m
+++ b/UncrustifyX/UXDefaultsManager.m
@@ -22,6 +22,7 @@ static NSString *const UXExportBlankOptionsKey                      = @"UXExport
 static NSString *const UXLanguagesIncludedInDocumentationKey        = @"UXLanguagesIncludedInDocumentation";
 static NSString *const UXSelectedPreviewLanguageInDocumentationKey  = @"UXSelectedPreviewLanguageInDocumentation";
 static NSString *const UXSelectedPreviewLanguageInMainWindowKey     = @"UXSelectedPreviewLanguageInMainWindow";
+static NSString *const UXLastConfigBookmarkKey     					= @"UXLastConfigBookmarkKey";
 
 @implementation UXDefaultsManager
 
@@ -132,6 +133,31 @@ static NSString *const UXSelectedPreviewLanguageInMainWindowKey     = @"UXSelect
 
 - (void)setSelectedPreviewLanguageInMainWindow:(NSString *)languageCode {
     [self setDefaultsObject:languageCode forKey:UXSelectedPreviewLanguageInMainWindowKey];
+}
+
+- (NSURL *)lastConfigURL {
+    NSURL *retURL = nil;
+    NSData* bookmarkData = [self defaultsObjectForKey:UXLastConfigBookmarkKey];
+    if (bookmarkData) {
+        retURL = [NSURL URLByResolvingBookmarkData:bookmarkData
+                                           options:NSURLBookmarkResolutionWithoutUI
+                                     relativeToURL:nil
+                               bookmarkDataIsStale:NULL
+                                             error:NULL];
+    }
+    return retURL;
+}
+
+- (void)setLastConfigURL:(NSURL *)lastConfigURL {
+    NSParameterAssert(lastConfigURL);
+    NSData* data = [lastConfigURL bookmarkDataWithOptions:NSURLBookmarkCreationSuitableForBookmarkFile
+                       includingResourceValuesForKeys:nil
+                                        relativeToURL:nil
+                                                error:NULL];
+    NSAssert(data, @"Failed to create a bookmark for the given config url %@", lastConfigURL);
+    if (data) {
+        [[NSUserDefaults standardUserDefaults] setObject:data forKey:UXLastConfigBookmarkKey];
+    }
 }
 
 #pragma mark -


### PR DESCRIPTION
I made some changes in the Open and Save panels used for the configuration.
- By default, hidden files are hidden: it's quite unpleasant to see all the hidden files in the panel but it's a personal opinion. The user can show/hide the hidden files by using command shift period (default OS X feature in NSOpenPanel / NSSavePanel).
- The last accessed file url is persistent. A bookmark is used, so even if the file moves, the next time, the url will stay valid and will reflect the new path.
